### PR TITLE
Internalize variables -> self.variables & add revenue functions within a class 

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,16 +64,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x13f2a540a30>"
+       "<matplotlib.legend.Legend at 0x218539ba2c0>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -117,14 +117,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "optimizer_flex = optimizer(solverpath_exe='C:\\glpk\\w64\\glpsol')\n",
     "step1_soc_daa,step1_cha_daa,step1_dis_daa, step1_profit_daa = optimizer_flex.step1_optimize_daa(n_cycles=1, energy_cap=1, power_cap=1, daa_price_vector=daa_price_vector)\n",
-    "step2_soc_ida, step2_cha_ida, step2_dis_ida, step2_cha_ida_close, step2_dis_ida_close, step2_profit_ida, step2_cha_daaida, step2_dis_daaida = optimizer_flex.step2_optimize_ida(n_cycles=1, energy_cap=1, power_cap=1, ida_price_vector=ida_price_vector, step1_cha_daa=step1_cha_daa, step1_dis_daa=step1_dis_daa)\n",
-    "step3_soc_idc, step3_cha_idc, step3_dis_idc, step3_cha_idc_close, step3_dis_idc_close, step3_profit_idc, step3_cha_daaidaidc, step3_dis_daaidaidc = optimizer_flex.step3_optimize_idc(n_cycles=1, energy_cap=1, power_cap=1, idc_price_vector=idc_price_vector, step2_cha_daaida=step2_cha_daaida, step2_dis_daaida=step2_dis_daaida)"
+    "step2_soc_ida, step2_cha_ida, step2_dis_ida, step2_cha_ida_close, step2_dis_ida_close, step2_profit_ida, step2_cha_daaida, step2_dis_daaida = optimizer_flex.step2_optimize_ida(n_cycles=1, energy_cap=1, power_cap=1, ida_price_vector=ida_price_vector)\n",
+    "step3_soc_idc, step3_cha_idc, step3_dis_idc, step3_cha_idc_close, step3_dis_idc_close, step3_profit_idc, step3_cha_daaidaidc, step3_dis_daaidaidc = optimizer_flex.step3_optimize_idc(n_cycles=1, energy_cap=1, power_cap=1, idc_price_vector=idc_price_vector)"
    ]
   },
   {
@@ -136,15 +136,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# The revenue formula for each market are as fallows\n",
     "revenue_daa = np.sum(np.asarray(daa_price_vector) * (np.asarray(step1_dis_daa) - step1_cha_daa)) * 1/4\n",
     "revenue_ida = np.sum(np.asarray(ida_price_vector) * (np.asarray(step2_dis_ida) + step2_dis_ida_close - step2_cha_ida - step2_cha_ida_close)) * 1/4\n",
     "revenue_idc = np.sum(np.asarray(idc_price_vector) * (np.asarray(step3_dis_idc) + step3_dis_idc_close - step3_cha_idc - step3_cha_idc_close)) * 1/4\n",
     "\n",
     "revenue_total = revenue_daa+revenue_ida+revenue_idc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The optimizer class contains revenue caculcation internally.\n",
+    "revenue_daa = optimizer_flex.revenue_daa()\n",
+    "revenue_ida = optimizer_flex.revenue_ida()\n",
+    "revenue_idc = optimizer_flex.revenue_idc()\n",
+    "revenue_total = optimizer_flex.revenue_total()"
    ]
   },
   {
@@ -156,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
This pull request addresses the two issues about optimizer.py and suggests improvements. 

1. Internalize variables in each function into a class 
For example, in the step1_optimize_daa function, I modified `step1_cha_daa` to `self.step1_cha_daa`. By doing so, the step2_optimize_ida function no longer needs the step1 function's return value. 
That is, step2 function requires fewer arguments than previous: From `step2_optimize_ida(self, ..., ida_price_vector: list, step1_cha_daa: list, step1_dis_daa: list)` to `step2_optimize_ida(self,..., ida_price_vector: list)`. The same logic is applied to the step3 functions (i.e. it no longer needs step2 return values). 
2. Add revenue functions within a class 
Previously, revenue values( DAA, IDA, IDC) were calculated outside the optimizer class. So, I added the revenue functions inside the class for convenience. 
For example, 

```{python}
    def revenue_daa(self) -> float:
        # Calculate the revenue of DAA market

        return(np.sum(np.asarray(self.daa_price_vector) * (np.asarray(self.step1_dis_daa) - self.step1_cha_daa)) * 1/4)
```
So you can calculate the revenue just by calling the function 
```{python}
revenue_daa = optimizer_flex.revenue_daa()
````

Because all variables within the class are internalized, the revenue_daa function doesn't need any additional argument.  You can see the example in the modified example.ipynb.

Thank you for reviewing this pull request. I'm eager to address any feedback and further improve the bess_optimizer.  
